### PR TITLE
1.0.79

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.5.25277.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-preview.5.25277.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.5.25277.114" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-preview.5.25277.114" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,32 +16,32 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.4.25258.110" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-preview.4.25258.110" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.5.25277.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-preview.5.25277.11" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Serilog" Version="4.2.0" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="xunit.v3" Version="2.0.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.6" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageVersion Include="Dapper" Version="2.1.66" />

--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor>1</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>78</VersionPatch>
+    <VersionPatch>79</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request updates several package versions and increments the project version patch number. These changes ensure the project uses the latest dependencies and aligns with semantic versioning practices.

### Dependency Updates:

* Updated multiple package versions in `Directory.Packages.props`, including `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Logging`, `Serilog`, `Microsoft.NET.Test.Sdk`, `xunit.v3`, `BenchmarkDotNet`, and `Microsoft.EntityFrameworkCore` to their latest versions.
* Update to .NET 10 Preview 5 for `net10.0`

### Versioning:

* Incremented the `VersionPatch` number from `78` to `79` in `build/version.props` to reflect a new patch release.