### PR TITLE
1.0.81

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,13 +16,13 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.6.25358.103" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-preview.6.25358.103" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25380.108" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25380.108" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
@@ -39,9 +39,9 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.8" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageVersion Include="Dapper" Version="2.1.66" />

--- a/WeihanLi.Common.sln.DotSettings
+++ b/WeihanLi.Common.sln.DotSettings
@@ -2,4 +2,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CA/@EntryIndexedValue">CA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sourcebranchname/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Weihan/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/build/build.cs
+++ b/build/build.cs
@@ -1,12 +1,6 @@
 // Copyright (c) Weihan Li. All rights reserved.
 // Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 
-var target = CommandLineParser.Val(args, "target", "Default");
-var apiKey = CommandLineParser.Val(args, "apiKey");
-var stable = CommandLineParser.BooleanVal(args, "stable");
-var noPush = CommandLineParser.BooleanVal(args, "noPush");
-var branchName = EnvHelper.Val("BUILD_SOURCEBRANCHNAME", "local");
-
 var solutionPath = "./WeihanLi.Common.slnx";
 string[] srcProjects = [ 
     "./src/WeihanLi.Common/WeihanLi.Common.csproj",
@@ -15,110 +9,12 @@ string[] srcProjects = [
 ];
 string[] testProjects = [ "./test/WeihanLi.Common.Test/WeihanLi.Common.Test.csproj" ];
 
-await new BuildProcessBuilder()
-    .WithSetup(() =>
+await DotNetPackageBuildProcess
+    .Create(options => 
     {
-        // cleanup artifacts
-        if (Directory.Exists("./artifacts/packages"))
-            Directory.Delete("./artifacts/packages", true);
-
-        // args
-        Console.WriteLine("Arguments");
-        Console.WriteLine($"    {args.StringJoin(" ")}");
+        options.SolutionPath = solutionPath;
+        options.SrcProjects = srcProjects;
+        options.TestProjects = testProjects;
     })
-    .WithTaskExecuting(task => Console.WriteLine($@"===== Task {task.Name} {task.Description} executing ======"))
-    .WithTaskExecuted(task => Console.WriteLine($@"===== Task {task.Name} {task.Description} executed ======"))
-    .WithTask("hello", b => b.WithExecution(async () =>
-    {
-        Console.WriteLine("Hello dotnet-exec build");
-        await ExecuteCommandAsync("dotnet-exec info");
-    }))
-    .WithTask("build", b =>
-    {
-        b.WithDescription("dotnet build")
-            .WithExecution(() => ExecuteCommandAsync($"dotnet build {solutionPath}"))
-            ;
-    })
-    .WithTask("test", b =>
-    {
-        b.WithDescription("dotnet test")
-            .WithDependency("build")
-            .WithExecution(async () =>
-            {
-                foreach (var project in testProjects)
-                {
-                    await ExecuteCommandAsync($"dotnet test --collect:\"XPlat Code Coverage;Format=cobertura,opencover;ExcludeByAttribute=ExcludeFromCodeCoverage,Obsolete,GeneratedCode,CompilerGeneratedAttribute\" {project}");
-                }
-            })
-            ;
-    })
-    .WithTask("pack", b => b.WithDescription("dotnet pack")
-        .WithDependency("test")
-        .WithExecution(async () =>
-        {
-            if (stable || branchName == "master")
-            {
-                foreach (var project in srcProjects)
-                {
-                    await ExecuteCommandAsync($"dotnet pack {project} -o ./artifacts/packages");
-                }
-            }
-            else
-            {
-                var suffix = $"preview-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
-                foreach (var project in srcProjects)
-                {
-                    await ExecuteCommandAsync($"dotnet pack {project} -o ./artifacts/packages --version-suffix {suffix}");
-                }
-            }            
+    .ExecuteAsync(args);
 
-            if (noPush)
-            {
-                Console.WriteLine("Skip push there's noPush specified");
-                return;
-            }
-            
-            if (string.IsNullOrEmpty(apiKey))
-            {
-                // try to get apiKey from environment variable
-                apiKey = Environment.GetEnvironmentVariable("NuGet__ApiKey");
-                
-                if (string.IsNullOrEmpty(apiKey))
-                {
-                    Console.WriteLine("Skip push since there's no apiKey found");
-                    return;
-                }
-            }
-
-            if (branchName != "master" && branchName != "preview")
-            {
-                Console.WriteLine($"Skip push since branch name {branchName} not support push packages");
-                return;
-            }
-
-            // push nuget packages
-            foreach (var file in Directory.GetFiles("./artifacts/packages/", "*.nupkg"))
-            {
-                await ExecuteCommandAsync($"dotnet nuget push {file} -k {apiKey} --skip-duplicate", [new("$NuGet__ApiKey", apiKey)]);
-            }
-        }))
-    .WithTask("Default", b => b.WithDependency("hello").WithDependency("pack"))
-    .Build()
-    .ExecuteAsync(target, ApplicationHelper.ExitToken);
-
-async Task ExecuteCommandAsync(string commandText, KeyValuePair<string, string>[]? replacements = null)
-{
-    var commandTextWithReplacements = commandText;
-    if (replacements is { Length: > 0})
-    {
-        foreach (var item in replacements)
-        {
-            commandTextWithReplacements = commandTextWithReplacements.Replace(item.Value, item.Key);
-        }
-    }
-    Console.WriteLine($"Executing command: \n    {commandTextWithReplacements}");
-    Console.WriteLine();
-    var result = await CommandExecutor.ExecuteCommandAndOutputAsync(commandText);
-    result.EnsureSuccessExitCode();
-    Console.WriteLine();
-}

--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor>1</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>80</VersionPatch>
+    <VersionPatch>81</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WeihanLi.Common/Helpers/HttpHelper.cs
+++ b/src/WeihanLi.Common/Helpers/HttpHelper.cs
@@ -84,7 +84,6 @@ public static class HttpHelper
     private static readonly Lazy<HttpClient> SharedHttpClient = new(() => new(new NoProxyHttpClientHandler()
     {
         UseCookies = false,
-        CheckCertificateRevocationList = false,
 #if NET
         AutomaticDecompression = DecompressionMethods.All
 #else

--- a/src/WeihanLi.Common/Helpers/HttpHelper.cs
+++ b/src/WeihanLi.Common/Helpers/HttpHelper.cs
@@ -84,6 +84,7 @@ public static class HttpHelper
     private static readonly Lazy<HttpClient> SharedHttpClient = new(() => new(new NoProxyHttpClientHandler()
     {
         UseCookies = false,
+        CheckCertificateRevocationList = false,
 #if NET
         AutomaticDecompression = DecompressionMethods.All
 #else

--- a/src/WeihanLi.Common/Helpers/InvokeHelper.cs
+++ b/src/WeihanLi.Common/Helpers/InvokeHelper.cs
@@ -10,7 +10,7 @@ public static class InvokeHelper
 {
     static InvokeHelper()
     {
-        OnInvokeException = ex => Debug.WriteLine(ex);
+        OnInvokeException = ex => ConsoleHelper.WriteLineWithColor(ex.ToString(), ConsoleColor.DarkRed);
 
         #region Exit event register
 

--- a/src/WeihanLi.Common/Http/NoProxyHttpClientHandler.cs
+++ b/src/WeihanLi.Common/Http/NoProxyHttpClientHandler.cs
@@ -8,5 +8,6 @@ public sealed class NoProxyHttpClientHandler : HttpClientHandler
         UseProxy = false;
         UseCookies = false;
         AllowAutoRedirect = false;
+        CheckCertificateRevocationList = false;
     }
 }


### PR DESCRIPTION
This pull request mainly updates package dependencies to their latest versions and introduces a few minor code improvements. The most important changes are grouped below:

**Dependency Updates:**

* Updated several `Microsoft.Extensions.*` and `Microsoft.EntityFrameworkCore` package versions for `.NET 9.0` and `.NET 10.0` targets in `Directory.Packages.props` to the latest stable or preview releases. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L19-R25) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L42-R44)

**Code Improvements:**

* Changed the default exception logging in `InvokeHelper` from writing to debug output to displaying the exception message in dark red on the console using `ConsoleHelper.WriteLineWithColor`.
* Set `CheckCertificateRevocationList = false;` in the `NoProxyHttpClientHandler` constructor to disable certificate revocation checks to work around .NET 10 preview issues with some url.

**Versioning:**

* Bumped the patch version from `80` to `81` in `build/version.props`.