### PR TITLE
1.0.84

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -166,7 +166,7 @@ dotnet build
 dotnet test
 
 # Run custom build script
-./build.sh
+dotnet build.cs
 
 # Format code
 dotnet format

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -33,4 +33,4 @@ jobs:
     - name: dotnet info
       run: dotnet --info
     - name: build
-      run: bash build.sh
+      run: dotnet build.cs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       run: dotnet build.cs --stable=true
     - name: Get Release Version
       shell: pwsh
-      run: dotnet-exec ./build/exportReleaseVersion.cs
+      run: dotnet ./build/exportReleaseVersion.cs
     - name: create release
       shell: pwsh
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           10.0.x
     - name: Build
       shell: pwsh
-      run: .\build.ps1 --stable=true
+      run: dotnet build.cs --stable=true
     - name: Get Release Version
       shell: pwsh
       run: dotnet-exec ./build/exportReleaseVersion.cs

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.11" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25502.107" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0-rc.2.25502.107" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
@@ -32,17 +32,17 @@
     <PackageVersion Include="Serilog" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3" Version="3.1.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.6" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.10" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.2" />
     <PackageVersion Include="Dapper" Version="2.1.66" />
   </ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,8 +39,8 @@ steps:
 - script: dotnet --info
   displayName: 'dotnet info'
 
-- powershell: ./build.ps1
-  displayName: 'Powershell Script'
+- script: dotnet build.cs
+  displayName: 'Build Script'
   env:
     Nuget__ApiKey: $(nugetApiKey)
 

--- a/build.cs
+++ b/build.cs
@@ -1,6 +1,13 @@
 // Copyright (c) Weihan Li. All rights reserved.
 // Licensed under the Apache license version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 
+#:project ./src/WeihanLi.Common/WeihanLi.Common.csproj
+#:property PublishAot=false
+
+using WeihanLi.Common;
+using WeihanLi.Common.Helpers;
+using WeihanLi.Extensions;
+
 var solutionPath = "./WeihanLi.Common.slnx";
 string[] srcProjects = [ 
     "./src/WeihanLi.Common/WeihanLi.Common.csproj",

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,0 @@
-dotnet tool update -g dotnet-execute --prerelease
-
-Write-Host 'dotnet-exec ./build/build.cs "--args=$ARGS"' -ForegroundColor GREEN
- 
-dotnet-exec ./build/build.cs --wide false --reference "project:./src/WeihanLi.Common/WeihanLi.Common.csproj" --using "WeihanLi.Common" --using "WeihanLi.Extensions" --using "WeihanLi.Common.Helpers" --args $ARGS

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-dotnet tool update -g dotnet-execute --prerelease
-export PATH="$PATH:$HOME/.dotnet/tools"
-
-echo "dotnet-exec ./build/build.cs --args $@"
-dotnet-exec ./build/build.cs --wide false --reference "project:./src/WeihanLi.Common/WeihanLi.Common.csproj" --using "WeihanLi.Common" --using "WeihanLi.Extensions" --using "WeihanLi.Common.Helpers" --args "$@"

--- a/build/exportReleaseVersion.cs
+++ b/build/exportReleaseVersion.cs
@@ -3,9 +3,10 @@ Console.WriteLine($"currentDirectory: {currentDirectory}");
 
 var versionPropsFile = "./build/version.props";
 var doc = System.Xml.Linq.XDocument.Load(versionPropsFile);
-var propertyGroupNode = doc.Element("Project").Element("PropertyGroup");
+var propertyGroupNode = doc.Element("Project")?.Element("PropertyGroup");
+ArgumentNullException.ThrowIfNull(propertyGroupNode);
 
-var version = $"{propertyGroupNode.Element("VersionMajor").Value}.{propertyGroupNode.Element("VersionMinor").Value}.{propertyGroupNode.Element("VersionPatch").Value}";
+var version = $"{propertyGroupNode.Element("VersionMajor")!.Value}.{propertyGroupNode.Element("VersionMinor")!.Value}.{propertyGroupNode.Element("VersionPatch")!.Value}";
 Console.WriteLine($"Version: {version}");
 
 var envFile = Environment.GetEnvironmentVariable("GITHUB_ENV");

--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor>1</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>83</VersionPatch>
+    <VersionPatch>84</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
.NET 10 GA Release

This pull request updates the build and release process for the project, replacing custom shell and PowerShell scripts with direct usage of `dotnet build.cs`, and modernizes package dependencies. The changes streamline CI/CD pipelines and improve reliability by using more standard tooling and updating key dependencies.

**Build and CI/CD Pipeline Modernization:**

* Replaced usage of custom build scripts (`build.sh`, `build.ps1`) with direct invocation of `dotnet build.cs` in documentation, GitHub Actions workflows, and Azure Pipelines, standardizing the build process across environments. [[1]](diffhunk://#diff-d21d0d50a9a1009406e71fca88ddcd4982d97d93924c405c162cd036f7a2447bL169-R169) [[2]](diffhunk://#diff-54411c2dc70cdd657fcf8a7bdebeff500fbb1245570abb83c22b3f62db03e71bL36-R36) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-R24) [[4]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L42-R43) [[5]](diffhunk://#diff-f75c72f619c834df67ead71ce04b2492c5b469f857a3c618e56363d34fd02075R4-R10) [[6]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL1-L5) [[7]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L1-L7)

* Updated the release workflow to use `dotnet build.cs --stable=true` and improved the release version extraction script for null safety and code clarity. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-R24) [[2]](diffhunk://#diff-6db84901bd7769537ee8aaa5262d79890379dcb2079fa56e9a7875adc0d28adfL6-R9)

**Dependency Updates:**

* Upgraded several NuGet package versions for .NET 9.0 and 10.0 targets, including `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Logging`, `Microsoft.EntityFrameworkCore`, `Serilog.Sinks.Console`, `Microsoft.NET.Test.Sdk`, and `BenchmarkDotNet`. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L19-R25) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L35-R45)

**Versioning:**

* Bumped the patch version from 83 to 84 in `build/version.props` to reflect the new release.