### PR TITLE
Fix typo, Also remove redundant interface inheritance

### DIFF
--- a/src/WeihanLi.Common/Models/BaseEntity.cs
+++ b/src/WeihanLi.Common/Models/BaseEntity.cs
@@ -39,7 +39,7 @@ public interface IEntityWithUpdatedAtAndBy
     : IEntityWithUpdatedAt, IEntityWithUpdatedBy;
 
 public interface IEntityWithCreatedUpdatedAtAndBy
-    : IEntityWithCreatedUpdatedAt, IEntityWithCreatedUpdatedBy;
+    : IEntityWithCreatedUpdatedAt, IEntityWithCreatedUpdatedBy, IEntityWithUpdatedAtAndBy;
 
 public interface IEntityWithReviewState
 {

--- a/src/WeihanLi.Common/Models/BaseEntity.cs
+++ b/src/WeihanLi.Common/Models/BaseEntity.cs
@@ -39,7 +39,7 @@ public interface IEntityWithUpdatedAtAndBy
     : IEntityWithUpdatedAt, IEntityWithUpdatedBy;
 
 public interface IEntityWithCreatedUpdatedAtAndBy
-    : IEntityWithCreatedUpdatedAt, IEntityWithCreatedUpdatedBy, IEntityWithUpdatedAtAndBy;
+    : IEntityWithCreatedUpdatedAt, IEntityWithCreatedUpdatedBy;
 
 public interface IEntityWithReviewState
 {

--- a/src/WeihanLi.Common/WeihanLi.Common.csproj
+++ b/src/WeihanLi.Common/WeihanLi.Common.csproj
@@ -3,9 +3,9 @@
     <PackageId>WeihanLi.Common</PackageId>
     <Title>WeihanLi.Common</Title>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <Description>common libarary,extensions helpers and useful utilities</Description>
-    <PackageTags>$(PackageTags);common;utility;lib;libarary;extensions;helpers</PackageTags>
-    <PackageSummary>common libarary,extensions helpers and useful utilities</PackageSummary>
+    <Description>common library,extensions helpers and useful utilities</Description>
+    <PackageTags>$(PackageTags);common;utility;lib;library;extensions;helpers</PackageTags>
+    <PackageSummary>common library,extensions helpers and useful utilities</PackageSummary>
     <PackageProjectUrl>https://github.com/WeihanLi/WeihanLi.Common/tree/dev/src/WeihanLi.Common</PackageProjectUrl>
     <NoWarn>$(NoWarn);1591;DE0003;SYSLIB0014;</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
correct word `library` to fix typo in `WeihanLi.Common.csproj`