### PR TITLE
1.0.92

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,34 +16,34 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26359.118" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="11.0.0-preview.7.26381.103" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Serilog" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.3.2" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.3.3" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Dapper" Version="2.1.79" />

--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor>1</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionPatch>91</VersionPatch>
+    <VersionPatch>92</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WeihanLi.Core/Extensions/HttpClientExtension.cs
+++ b/src/WeihanLi.Core/Extensions/HttpClientExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Http.Headers;
 using WeihanLi.Common;
-using WeihanLi.Common.Helpers;
 using WeihanLi.Common.Http;
 
 // ReSharper disable once CheckNamespace

--- a/src/WeihanLi.Core/Extensions/HttpClientExtension.cs
+++ b/src/WeihanLi.Core/Extensions/HttpClientExtension.cs
@@ -1,5 +1,8 @@
 ﻿using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
 using WeihanLi.Common;
+using WeihanLi.Common.Helpers;
 using WeihanLi.Common.Http;
 
 // ReSharper disable once CheckNamespace
@@ -26,7 +29,7 @@ public static class HttpClientExtension
     /// </summary>
     /// <seealso cref="T:System.Net.Http.Headers.AuthenticationHeaderValue" />
     /// <remarks>
-    /// Initializes a new instance of the <see cref="T:System.Net.Http.BasicAuthenticationOAuthHeaderValue" /> class.
+    /// Initializes a new instance of the <see cref="BasicAuthenticationHeaderValue" /> class.
     /// </remarks>
     /// <param name="userName">Name of the user.</param>
     /// <param name="password">The password.</param>
@@ -283,5 +286,26 @@ public static class HttpClientExtension
     private static bool IsWellKnownContentHeader(string header)
     {
         return WellKnownContentHeaders.Contains(header);
+    }
+
+    extension(HttpContent)
+    {
+        public static StringContent CreateFromJson(
+            [StringSyntax(StringSyntaxAttribute.Json)]string json,
+            string mediaType = HttpHelper.ApplicationJsonMediaType,
+            Encoding? encoding = null
+            )
+        {
+            return new StringContent(json, encoding ?? Encoding.UTF8, mediaType);
+        }
+        
+        public static StringContent CreateFromYaml(
+            [StringSyntax("yaml")]string yaml,
+            string mediaType = HttpHelper.ApplicationYamlMediaType,
+            Encoding? encoding = null
+        )
+        {
+            return new StringContent(yaml, encoding ?? Encoding.UTF8, mediaType);
+        }
     }
 }

--- a/src/WeihanLi.Core/Extensions/HttpClientExtension.cs
+++ b/src/WeihanLi.Core/Extensions/HttpClientExtension.cs
@@ -291,16 +291,16 @@ public static class HttpClientExtension
     extension(HttpContent)
     {
         public static StringContent CreateFromJson(
-            [StringSyntax(StringSyntaxAttribute.Json)]string json,
+            [StringSyntax(StringSyntaxAttribute.Json)] string json,
             string mediaType = HttpHelper.ApplicationJsonMediaType,
             Encoding? encoding = null
             )
         {
             return new StringContent(json, encoding ?? Encoding.UTF8, mediaType);
         }
-        
+
         public static StringContent CreateFromYaml(
-            [StringSyntax("yaml")]string yaml,
+            [StringSyntax("yaml")] string yaml,
             string mediaType = HttpHelper.ApplicationYamlMediaType,
             Encoding? encoding = null
         )


### PR DESCRIPTION
This pull request primarily updates package versions and introduces new extension methods for creating `StringContent` from JSON and YAML strings. Additionally, it includes a minor documentation fix and increments the patch version.

**Dependency updates:**

* Updated several NuGet package versions in `Directory.Packages.props`, including `Microsoft.Extensions.*`, `Microsoft.EntityFrameworkCore`, `Microsoft.Bcl.AsyncInterfaces`, `GitHubActionsTestLogger`, and `Microsoft.Testing.Platform` to their latest patch or preview versions.

**New functionality:**

* Added extension methods to `HttpContent` for easily creating `StringContent` from JSON and YAML strings, with appropriate media types and encoding.

**Documentation and metadata:**

* Fixed a documentation comment to reference `BasicAuthenticationHeaderValue` correctly.
* Incremented the patch version from 91 to 92 in `build/version.props`.
* Added missing `using` statements for `System.Net.Mime` and `System.Text` in `HttpClientExtension.cs`.